### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-babbel/security/code-scanning/1](https://github.com/oszuidwest/zwfm-babbel/security/code-scanning/1)

To fix the problem, we should explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. For most CI workflows that only check out code and run tests, `contents: read` is sufficient. This can be set at the workflow root (applies to all jobs) or at the job level. Since there is only one job (`test`), either location is fine, but setting it at the root is clearer and future-proof. The change involves adding the following block near the top of the workflow file, after the `name` field and before `on`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
